### PR TITLE
 Feature: Support TSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ JSX:
 />
 ```
 
+##### TSX Support
+
+TSX does not support `:` in prefix. With TSX you may use `-` as the prefix. 
+
+```js
+export default {
+  render () {
+    return (
+      <input
+        onKeyup-up={this.methodForPressingUp}
+        onKeyup-down={this.methodForPressingDown}
+        onKeyup-bare-shift-enter={this.methodOnlyOnShiftEnter}
+        onKeyup-bare-alt-enter={this.methodOnlyOnAltEnter}
+      />
+    )
+  }
+}
+```
+
 ##### Notable differences:
 
  * Modifiers are prefixed by `:` and separated by `-` (in vue: prefixed by `.` and separated by `.`)

--- a/src/group-event-attributes.js
+++ b/src/group-event-attributes.js
@@ -4,11 +4,18 @@ export default t => (obj, attribute) => {
   }
 
   const isNamespaced = t.isJSXNamespacedName(attribute.get('name'))
-  const event = (isNamespaced ? attribute.get('name').get('namespace') : attribute.get('name')).get('name').node
-  const modifiers = isNamespaced ? new Set(attribute.get('name').get('name').get('name').node.split('-')) : new Set()
+  let event = (isNamespaced ? attribute.get('name').get('namespace') : attribute.get('name')).get('name').node
+  let modifiers = isNamespaced ? new Set(attribute.get('name').get('name').get('name').node.split('-')) : new Set()
 
   if (event.indexOf('on') !== 0) {
     return obj
+  }
+
+  // Support tsx (onClick-once)
+  const mods = event.split('-')
+  if (mods.length > 1) {
+    event = mods.splice(0, 1)[0]
+    modifiers = new Set(mods)
   }
 
   const value = attribute.get('value')

--- a/test/test.js
+++ b/test/test.js
@@ -35,3 +35,6 @@ snapshotTest(
 snapshotTest('Simple alias :enter', '<a onEvent:enter={this.action1} />')
 snapshotTest('Simple double alias :delete', '<a onEvent:delete={this.action1} />')
 snapshotTest('Simple key code :k120', '<a onEvent:k120={this.action1} />')
+
+// TSX support
+snapshotTest('- prefix -bare-alt-shift', '<a onEvent-bare-alt-shift={this.action1} />')


### PR DESCRIPTION
- Support TSX
  - TSX does not allow `:` in attribute name. 
  - Allow prefixing with `-` as prefix and seperator like `onClick-capture-once`
- Update tests
- Update README.md